### PR TITLE
fix: flag placeholder Zyte API keys

### DIFF
--- a/scrapy_lint/finders/settings/values.py
+++ b/scrapy_lint/finders/settings/values.py
@@ -413,6 +413,17 @@ def check_user_agent(node: expr, **_) -> Generator[Issue]:
         yield issue
 
 
+def check_zyte_api_key(node: expr, **_) -> Generator[Issue]:
+    if not isinstance(node, Constant) or not isinstance(node.value, str):
+        return
+    if not node.value.strip() or node.value.strip().casefold() == "your_api_key":
+        yield Issue(
+            INVALID_SETTING_VALUE,
+            Pos.from_node(node),
+            "ZYTE_API_KEY must not be empty or a placeholder",
+        )
+
+
 class ValueChecker(Protocol):  # pylint: disable=too-few-public-methods
     def __call__(self, node: expr, *, context: Context) -> Generator[Issue]: ...
 
@@ -422,4 +433,5 @@ VALUE_CHECKERS: dict[str, ValueChecker] = {
     "FEED_URI": check_feed_uri,
     "FEEDS": check_feeds,
     "USER_AGENT": check_user_agent,
+    "ZYTE_API_KEY": check_zyte_api_key,
 }

--- a/tests/test_setting_values.py
+++ b/tests/test_setting_values.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from ast import Constant
+
+from scrapy_lint.finders.settings.values import check_zyte_api_key
 from tests.helpers import check_project
 from tests.settings import SETTING_VALUE_CHECK_TEMPLATES, SafeDict, zip_with_template
 
@@ -841,3 +844,13 @@ def test(
     options,
 ):
     check_project(files, expected, options)
+
+
+def test_zyte_api_key_placeholders():
+    assert [issue.message for issue in check_zyte_api_key(Constant(""))] == [
+        "SCP36 invalid setting value: ZYTE_API_KEY must not be empty or a placeholder"
+    ]
+    assert [issue.message for issue in check_zyte_api_key(Constant("  YOUR_API_KEY  "))] == [
+        "SCP36 invalid setting value: ZYTE_API_KEY must not be empty or a placeholder"
+    ]
+    assert list(check_zyte_api_key(Constant("real-api-key"))) == []


### PR DESCRIPTION
## Summary

- flag empty and placeholder `ZYTE_API_KEY` values before deployment
- preserve dynamic and non-string setting values for runtime configuration
- cover valid and invalid literal key values

Closes #83

## Tests

- `.venv\\Scripts\\ruff.exe check scrapy_lint/finders/settings/values.py tests/test_setting_values.py`
- `.venv\\Scripts\\python.exe -m pytest tests/test_setting_values.py -q`