### PR TITLE
Fix requirements file option spelling

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -54,9 +54,9 @@ For example:
     "spiders/toscrape_com.py" = ["SCP46"]
 
 
-.. _requirements-file:
+.. _requirements_file:
 
-requirements-file
+requirements_file
 =================
 
 The path to the requirements file of the Scrapy project:
@@ -64,7 +64,7 @@ The path to the requirements file of the Scrapy project:
 .. code-block:: toml
 
     [tool.scrapy-lint]
-    requirements-file = "path/to/my-requirements.txt"
+    requirements_file = "path/to/my-requirements.txt"
 
 If not specified, a requirements file is looked up as follows:
 
@@ -72,5 +72,5 @@ If not specified, a requirements file is looked up as follows:
     and contains a root ``requirements`` key with a ``file`` value pointing to
     an existing file (path interpreted relative to the project root).
 
-#.  The ``requirements.txt`` file in the project root directory, i.e. where
-    ``scrapy.cfg`` lives.
+#.  The ``requirements.txt`` file in the current working directory (the project
+    root passed to scrapy-lint).

--- a/docs/rules/scp26.rst
+++ b/docs/rules/scp26.rst
@@ -16,7 +16,7 @@ the one determined by the :ref:`requirements file resolution logic
 Why is this bad?
 ================
 
-When you specify a requirements file using the :ref:`requirements-file` option,
+When you specify a requirements file using the :ref:`requirements_file` option,
 but your ``scrapinghub.yml`` points to a different requirements file, this
 creates an inconsistency between the requirements file that scrapy-lint checks
 and the one that you deploy to Scrapy Cloud.
@@ -25,7 +25,7 @@ and the one that you deploy to Scrapy Cloud.
 Example
 =======
 
-With :ref:`requirements-file` seto to ``requirements-dev.txt``:
+With :ref:`requirements_file` set to ``requirements-dev.txt``:
 
 .. code-block:: yaml
 

--- a/scrapy_lint/context.py
+++ b/scrapy_lint/context.py
@@ -58,7 +58,10 @@ class Project:
     @cached_property
     def requirements_file(self) -> Path | None:
         requirements_file: Path | None
-        path_str = self.scrapy_lint_options.get("requirements_file")
+        path_str = self.scrapy_lint_options.get(
+            "requirements-file",
+            self.scrapy_lint_options.get("requirements_file"),
+        )
         if path_str is not None:
             requirements_file = Path(path_str).resolve()
             if requirements_file.exists():

--- a/tests/test_scrapinghub.py
+++ b/tests/test_scrapinghub.py
@@ -488,6 +488,39 @@ CASES = [
         ),
         {"requirements_file": "requirements-dev.txt"},
     ),
+    # The documented option spelling is supported.
+    (
+        (
+            File(
+                "\n".join(
+                    [
+                        f"stack: {LATEST_KNOWN_STACK}",
+                        "requirements:",
+                        "  file: requirements.txt",
+                    ],
+                ),
+                "scrapinghub.yml",
+            ),
+            File("", "scrapy.cfg"),
+            File("", "requirements-dev.txt"),
+            File("", "requirements.txt"),
+        ),
+        (
+            *default_issues("requirements-dev.txt"),
+            issue("SCP26 requirements.file mismatch", line=3, column=8),
+            ExpectedIssue(
+                message="SCP24 missing stack requirements: aiohttp, "
+                "awscli, boto, boto3, jinja2, monkeylearn, pillow, pyyaml, "
+                "requests, scrapinghub, scrapinghub-entrypoint-scrapy, "
+                "scrapy-deltafetch, scrapy-dotpersistence, scrapy-magicfields, "
+                "scrapy-pagestorage, scrapy-querycleaner, "
+                "scrapy-splitvariants, scrapy-zyte-smartproxy, spidermon, "
+                "urllib3",
+                path="requirements-dev.txt",
+            ),
+        ),
+        {"requirements-file": "requirements-dev.txt"},
+    ),
     (
         (
             File(


### PR DESCRIPTION
Fixes #178.

The documented `requirements-file` spelling is now honored while preserving support for the existing `requirements_file` key. The documentation now reflects the supported option and the working-directory fallback behavior.

Tests: `python -m ruff check scrapy_lint/context.py tests/test_scrapinghub.py`; `python -m pytest tests/test_scrapinghub.py -q` (38 passed).